### PR TITLE
Refactor Set1 Challenge2

### DIFF
--- a/include/xor.h
+++ b/include/xor.h
@@ -3,10 +3,6 @@
 
 #include <stdint.h>
 
-#include "hex.h"
-
-uint8_t *xor_binarrays(const uint8_t *a, const uint8_t *b, size_t size);
-
-char *xor_hexstrs(const char *a, const char *b);
+void xor_binary(uint8_t *a, const uint8_t *b, size_t size);
 
 #endif

--- a/set1/challenge2/main.c
+++ b/set1/challenge2/main.c
@@ -1,17 +1,31 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "hex.h"
 #include "xor.h"
 
 int main(void)
 {
-	char a[] = "1c0111001f010100061a024b53535009181c";
-	char b[] = "686974207468652062756c6c277320657965";
-	char *res = xor_hexstrs(a, b);
+	const char a_hex[] = "1c0111001f010100061a024b53535009181c";
+	const char b_hex[] = "686974207468652062756c6c277320657965";
+	uint8_t *a_binary, *b_binary;
+	size_t binary_size;
+	char *xor_hex;
 
-	printf("XOR(\"%s\", \"%s\") = \"%s\"\n", a, b, res);
+	binary_size = b2fromhex_size(a_hex);
 
-	free(res);
+	a_binary = hex_decode(a_hex);
+	b_binary = hex_decode(b_hex);
+
+	xor_binary(a_binary, b_binary, binary_size);
+	free(b_binary);
+
+	xor_hex = hex_encode(a_binary, binary_size);
+	free(a_binary);
+
+	printf("%s\n^\n%s\n=\n%s\n", a_hex, b_hex, xor_hex);
+	printf("expected:\n746865206b696420646f6e277420706c6179\n");
+	free(xor_hex);
 
 	return EXIT_SUCCESS;
 }

--- a/set1/challenge2/tests/test_xor.c
+++ b/set1/challenge2/tests/test_xor.c
@@ -5,170 +5,58 @@
 #include "cTest.h"
 #include "../xor.c"
 
-/*** xor_binarrays ***/
+/*** xor_binary ***/
 
-int test_xor_binarrays_null(void)
+int test_xor_binary_null(void)
 {
-	int status = 0;
 	uint8_t bits[] = {0xFF};
+	uint8_t orig[] = {0xFF};
 
-	status += TEST_BYTE_ARR_EQ(xor_binarrays(NULL, NULL, 0), NULL, 0);
-	status += TEST_BYTE_ARR_EQ(xor_binarrays(bits, NULL, 1), NULL, 0);
-	status += TEST_BYTE_ARR_EQ(xor_binarrays(NULL, bits, 1), NULL, 0);
+	xor_binary(bits, NULL, 1);
+	xor_binary(NULL, bits, 1);
 
-	return status;
+	return TEST_BYTE_ARR_EQ(bits, orig, 1);
 }
 
-int test_xor_binarrays_single_byte(void)
+int test_xor_binary_empty(void)
 {
-	int status;
+	uint8_t bits[] = {0xFF};
+	uint8_t orig[] = {0xFF};
+
+	xor_binary(bits, bits, 0);
+
+	return TEST_BYTE_ARR_EQ(bits, orig, 1);
+}
+
+int test_xor_binary_single_byte(void)
+{
 	uint8_t a[] = {0xFF};
 	uint8_t b[] = {0xAA};
 	uint8_t expected[] = {0x55};
-	uint8_t *actual = xor_binarrays(a, b, 1);
 
-	status = TEST_BYTE_ARR_EQ(expected, actual, 1);
+	xor_binary(a, b, 1);
 
-	free(actual);
-
-	return status;
+	return TEST_BYTE_ARR_EQ(expected, a, 1);
 }
 
-int test_xor_binarrays_two_bytes(void)
+int test_xor_binary_two_bytes(void)
 {
-	int status;
 	uint8_t a[] = {0x12, 0x34};
 	uint8_t b[] = {0x56, 0x78};
 	uint8_t expected[] = {0x44, 0x4C};
-	uint8_t *actual = xor_binarrays(a, b, 2);
 
-	status = TEST_BYTE_ARR_EQ(expected, actual, 2);
+	xor_binary(a, b, 2);
 
-	free(actual);
-
-	return status;
+	return TEST_BYTE_ARR_EQ(expected, a, 2);
 }
 
-/*** xor_hexstrs ***/
-
-int test_xor_hexstrs_null(void)
-{
-	int status = 0;
-
-	status += TEST_STR_EQ(xor_hexstrs(NULL, NULL), NULL);
-	status += TEST_STR_EQ(xor_hexstrs("a", NULL), NULL);
-	status += TEST_STR_EQ(xor_hexstrs(NULL, "b"), NULL);
-
-	return status;
-}
-
-int test_xor_hexstrs_empty(void)
-{
-	int status = 0;
-
-	status += TEST_STR_EQ(xor_hexstrs("", "b"), NULL);
-	status += TEST_STR_EQ(xor_hexstrs("a", ""), NULL);
-
-	return status;
-}
-
-int test_xor_hexstrs_single_bytes(void)
-{
-	int status;
-	char *res;
-
-	res = xor_hexstrs("FF", "AA");
-	status = TEST_STR_EQ(res, "55");
-
-	free(res);
-
-	return status;
-}
-
-int test_xor_hexstrs_results_in_letters(void)
-{
-	int status;
-	char *res;
-
-	res = xor_hexstrs("00", "BC");
-	status = TEST_STR_EQ(res, "BC");
-
-	free(res);
-
-	return status;
-}
-
-int test_xor_hexstrs_lowercase(void)
-{
-	int status;
-	char *res;
-
-	res = xor_hexstrs("ff", "aa");
-	status = TEST_STR_EQ(res, "55");
-
-	free(res);
-
-	return status;
-}
-
-int test_xor_hexstrs_different_sizes(void)
-{
-	int status = 0;
-	char *res;
-
-	res = xor_hexstrs("FFAA", "AAFFCC");
-	status += TEST_STR_EQ(res, "5555");
-	free(res);
-
-	res = xor_hexstrs("AAFFCC", "FFAA");
-	status += TEST_STR_EQ(res, "5555");
-	free(res);
-
-	return status;
-}
-
-int test_xor_hexstrs_odd_length(void)
-{
-	int status;
-	char *res;
-
-	res = xor_hexstrs("FFF", "AAA");
-	status = TEST_STR_EQ(res, "555");
-
-	free(res);
-
-	return status;
-}
-
-int test_xor_hexstrs_cryptopals_example(void)
-{
-	int status;
-	char a[] = "1c0111001f010100061a024b53535009181c";
-	char b[] = "686974207468652062756c6c277320657965";
-	char expected[] = "746865206B696420646F6E277420706C6179";
-	char *actual = xor_hexstrs(a, b);
-
-	status = TEST_STR_EQ(expected, actual);
-
-	free(actual);
-
-	return status;
-}
 
 int main(void)
 {
-	REGISTER_TEST(test_xor_binarrays_null);
-	REGISTER_TEST(test_xor_binarrays_single_byte);
-	REGISTER_TEST(test_xor_binarrays_two_bytes);
-
-	REGISTER_TEST(test_xor_hexstrs_null);
-	REGISTER_TEST(test_xor_hexstrs_empty);
-	REGISTER_TEST(test_xor_hexstrs_single_bytes);
-	REGISTER_TEST(test_xor_hexstrs_results_in_letters);
-	REGISTER_TEST(test_xor_hexstrs_lowercase);
-	REGISTER_TEST(test_xor_hexstrs_different_sizes);
-	REGISTER_TEST(test_xor_hexstrs_odd_length);
-	REGISTER_TEST(test_xor_hexstrs_cryptopals_example);
+	REGISTER_TEST(test_xor_binary_null);
+	REGISTER_TEST(test_xor_binary_empty);
+	REGISTER_TEST(test_xor_binary_single_byte);
+	REGISTER_TEST(test_xor_binary_two_bytes);
 
 	return RUN_TESTS();
 }

--- a/set1/challenge2/xor.c
+++ b/set1/challenge2/xor.c
@@ -1,91 +1,26 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "hex.h"
 #include "xor.h"
 
 /* XOR two equal length binary arrays
  * params:
- * 	- a: binary array
- * 	- b: binary array
+ * 	- a: binary array (will be updated)
+ * 	- b: binary array (unchanged)
  * 	- size: size of `a` and `b`
  * returns:
- * 	uint8_t binary array of size `size` containing the result of a^b,
- * 	or NULL if either `a` or `b` is NULL
- * 	returned array has been dynamically allocated and should be freed by
- * 	user
+ * 	nothing
+ * side-effect:
+ * 	`a` has been updated to contain the result of `a` XORed with `b`
  */
-uint8_t *xor_binarrays(const uint8_t *a, const uint8_t *b, size_t size)
+void xor_binary(uint8_t *a, const uint8_t *b, size_t size)
 {
-	uint8_t *res;
 	int i;
 
-	if (!a || !b)
-		return NULL;
+	if (!a || !b || size == 0)
+		return;
 
-	res = calloc(size, sizeof(uint8_t));
 	for (i = 0; (size_t)i < size; ++i)
-		res[i] = a[i] ^ b[i];
-
-	return res;
-}
-
-/* XOR two equal length C-string representing hex strings
- * params:
- * 	- a: C-string with characters in range [0, 1, ..., 9, A, ..., F]
- * 	     representing a hex string
- * 	- b: C-string with characters in range [0, 1, ..., 9, A, ..., F]
- * 	     representing a hex string
- * returns:
- * 	C-string of the same length as the smallest of either `a` or `b`
- * 	containing the result of a^b
- * 	or NULL if either `a` or `b` is NULL
- * 	or if either `a` or `b` is an invalid hex string
- * 	returned C-string has been dynamically allocated and should be freed by
- * 	user
- */
-char *xor_hexstrs(const char *a, const char *b)
-{
-	char *res, *resoddlen;
-	uint8_t *a_bin, *b_bin;
-	size_t a_len, b_len, min_len;
-	size_t a_bin_size, b_bin_size, min_size;
-	uint8_t *res_bin;
-
-	if (!a || !b)
-		return NULL;
-
-	a_bin = hex_decode(a);
-	b_bin = hex_decode(b);
-
-	if (!a_bin || !b_bin) {
-		if (!a_bin && b_bin)
-			free(b_bin);
-		else if (!b_bin && a_bin)
-			free(a_bin);
-		return NULL;
-	}
-
-	a_len = strlen(a);
-	b_len = strlen(b);
-	min_len = (a_len <= b_len) ? a_len : b_len;
-
-	a_bin_size = b2fromhex_size(a);
-	b_bin_size = b2fromhex_size(b);
-	min_size = (a_bin_size <= b_bin_size) ? a_bin_size : b_bin_size;
-
-	res_bin = xor_binarrays(a_bin, b_bin, min_size);
-	free(a_bin);
-	free(b_bin);
-
-	res = hex_encode(res_bin, min_size);
-	free(res_bin);
-
-	if (min_len%2 != 0) {
-		resoddlen = calloc(min_len+1, sizeof(char));
-		strcpy(resoddlen, res+1);
-		free(res);
-		return resoddlen;
-	}
-
-	return res;
+		a[i] ^= b[i];
 }


### PR DESCRIPTION
Refactor `xor_binary` to output the result into the first binary array rather than in a new one.
(The user can always copy the array before hand if a copy of the original must be kept)
This makes this method more reusable and will allow for it to be used be the repeated xor implementation.

Remove `xor_hexstr`, with clear hex encode/decode methods it is now easy for the user to go back and forth.